### PR TITLE
Added possibility for two static image inputs

### DIFF
--- a/framework/Source/GPUImageTwoInputFilter.m
+++ b/framework/Source/GPUImageTwoInputFilter.m
@@ -214,7 +214,7 @@ NSString *const kGPUImageTwoInputTextureVertexShaderString = SHADER_STRING
         return;
     }
     
-    BOOL updatedMovieFrameOppositeStillImage = NO;
+    BOOL haveNeededFrames = NO;
     
     if (textureIndex == 0)
     {
@@ -225,12 +225,10 @@ NSString *const kGPUImageTwoInputTextureVertexShaderString = SHADER_STRING
             hasReceivedSecondFrame = YES;
         }
         
-        if (!CMTIME_IS_INDEFINITE(frameTime))
+        // If second frame is indefinite, we are read to proceed, either it is also a still image or a movie, either is fine
+        if CMTIME_IS_INDEFINITE(secondFrameTime)
         {
-            if CMTIME_IS_INDEFINITE(secondFrameTime)
-            {
-                updatedMovieFrameOppositeStillImage = YES;
-            }
+            haveNeededFrames = YES;
         }
     }
     else
@@ -241,18 +239,16 @@ NSString *const kGPUImageTwoInputTextureVertexShaderString = SHADER_STRING
         {
             hasReceivedFirstFrame = YES;
         }
-
-        if (!CMTIME_IS_INDEFINITE(frameTime))
+        
+        // If first frame is indefinite, we are read to proceed, either it is also a still image or a movie, either is fine
+        if CMTIME_IS_INDEFINITE(firstFrameTime)
         {
-            if CMTIME_IS_INDEFINITE(firstFrameTime)
-            {
-                updatedMovieFrameOppositeStillImage = YES;
-            }
+            haveNeededFrames = YES;
         }
     }
-
+    
     // || (hasReceivedFirstFrame && secondFrameCheckDisabled) || (hasReceivedSecondFrame && firstFrameCheckDisabled)
-    if ((hasReceivedFirstFrame && hasReceivedSecondFrame) || updatedMovieFrameOppositeStillImage)
+    if ((hasReceivedFirstFrame && hasReceivedSecondFrame) || haveNeededFrames)
     {
         CMTime passOnFrameTime = (!CMTIME_IS_INDEFINITE(firstFrameTime)) ? firstFrameTime : secondFrameTime;
         [super newFrameReadyAtTime:passOnFrameTime atIndex:0]; // Bugfix when trying to record: always use time from first input (unless indefinite, in which case use the second input)


### PR DESCRIPTION
**GPUImageLookupFilter** gets stuck in case its used with a **GPUImagePicture** because both inputs to **GPUImageTwoInputFilter** are then with indefinite frame times which causes second frame to never be classed as "received" and thus _super newFrameReadyAtTime_ not being called ever.
Changed to proceed as long as one frame is updated and the other one has an indefinite time.
